### PR TITLE
Added HAProxy with Docker Compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,22 +1,34 @@
 version: '3'
 services:
+  haproxy:
+    image: haproxy
+    ports:
+      - "80:80"
+    volumes:
+      - ./infrastructure:/usr/local/etc/haproxy
+    networks:
+      - dockerdev
   frontend:
     build:
       context: ./frontend/
     environment:
       NODE_ENV: production
     ports:
-      - 3001:3001
+      - :3001
     networks:
       - dockerdev
+    deploy:
+      replicas: 3
   go-backend:
     build:
       context: ./backend/go-api/
       target: final
     ports:
-      - 8080:8080
+      - :8080
     networks:
       - dockerdev
+    deploy:
+      replicas: 3
 networks:
   dockerdev:
     driver: bridge

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,7 @@ services:
     image: haproxy
     ports:
       - "80:80"
+      - "8404:8404"
     volumes:
       - ./infrastructure:/usr/local/etc/haproxy
     networks:
@@ -18,7 +19,7 @@ services:
     networks:
       - dockerdev
     deploy:
-      replicas: 3
+      replicas: 4
   go-backend:
     build:
       context: ./backend/go-api/
@@ -28,7 +29,7 @@ services:
     networks:
       - dockerdev
     deploy:
-      replicas: 3
+      replicas: 5
 networks:
   dockerdev:
     driver: bridge

--- a/infrastructure/haproxy.cfg
+++ b/infrastructure/haproxy.cfg
@@ -1,0 +1,13 @@
+# haproxy.cfg
+frontend http
+    bind *:80
+    mode http
+    timeout client 10s
+    use_backend all
+
+backend react
+    mode http
+    server f1 frontend:3001
+backend goapi
+    mode http
+    server b1 go-backend:8080

--- a/infrastructure/haproxy.cfg
+++ b/infrastructure/haproxy.cfg
@@ -1,13 +1,19 @@
 # haproxy.cfg
 frontend http
-    bind *:80
-    mode http
-    timeout client 10s
-    use_backend all
-
+mode http
+    option httplog
+    bind *:80       
+    option forwardfor
+    acl host_front hdr(host) -i calc.test.local
+    acl host_api hdr(host) -i api.test.local
+    
+    use_backend react if host_front
+    use_backend goapi if host_api
+    
 backend react
     mode http
     server f1 frontend:3001
 backend goapi
     mode http
     server b1 go-backend:8080
+

--- a/infrastructure/haproxy.cfg
+++ b/infrastructure/haproxy.cfg
@@ -9,6 +9,13 @@ mode http
     
     use_backend react if host_front
     use_backend goapi if host_api
+frontend stats
+    mode http
+    bind *:8404
+    stats enable
+    stats uri /stats
+    stats refresh 10s
+    stats admin if LOCALHOST
     
 backend react
     mode http


### PR DESCRIPTION
- Modified the docker compose stack to have haproxy in proxy to load balance to arbitrary number of containers, targeted by servicename.
- 